### PR TITLE
fix: hasSources returning false

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,9 +8,5 @@ import { DeclarationReflection, ReferenceReflection, Reflection, SignatureReflec
 export function hasSources(
     reflection: Reflection,
 ): reflection is DeclarationReflection | ReferenceReflection | SignatureReflection {
-    return (
-        reflection instanceof DeclarationReflection ||
-        reflection instanceof ReferenceReflection ||
-        reflection instanceof SignatureReflection
-    );
+    return 'sources' in reflection;
 }


### PR DESCRIPTION
In testing the change for https://github.com/krisztianb/typedoc-plugin-replace-text/issues/9, I noticed the `this.sources` array was always `undefined` in the replacer function. Changing the `hasSources` function to check for the existence of the `sources` key rather than doing an `instanceof` check resolves the issue for me.